### PR TITLE
Potential fix for code scanning alert no. 6: Use of externally-controlled format string

### DIFF
--- a/workers/csv-validator.worker.js
+++ b/workers/csv-validator.worker.js
@@ -246,7 +246,8 @@ try {
             valid = validate(processedRowData);
           } catch (err) {
             console.error(
-              `Worker: Error during conversion/structure for row ${csvRowNum}:`,
+              "Worker: Error during conversion/structure for row %s:",
+              csvRowNum,
               err,
             );
             conversionErrorMsg = err.message || "Unknown conversion error";


### PR DESCRIPTION
Potential fix for [https://github.com/FabienDostieIT/CSV_Data_Validator/security/code-scanning/6](https://github.com/FabienDostieIT/CSV_Data_Validator/security/code-scanning/6)

To fix the issue, we will ensure that the format string does not directly interpolate the untrusted `csvRowNum` value. Instead, we will use a `%s` specifier in the format string and pass `csvRowNum` as a separate argument to `console.error`. This approach prevents any unintended format string injection, as the value will be treated as a string literal.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
